### PR TITLE
Data Separation of Dev and Prod

### DIFF
--- a/projects/mybyte/context/AuthContext.tsx
+++ b/projects/mybyte/context/AuthContext.tsx
@@ -69,15 +69,12 @@ export const AuthContextProvider = ({
   const [loading, setLoading] = useState<boolean>(true);
   const [currEvent, setCurrEvent] = useState<Events>();
 
-  // Stage Environment
-  const userRefStage = collection(db, "users-stage");
-  const eSportsRefStage = collection(db, "user-e-sports-details-stage");
-  const registerRefStage = collection(db, "user-registration-details-stage");
-
-  // Prod Environment
-  const userRef = collection(db, "users");
-  const eSportsRef = collection(db, "user-e-sports-details");
-  const registerRef = collection(db, "user-registration-details");
+  const devOrProd = process.env.NODE_ENV == "development"; // if being run with yarn dev
+  const extra = (devOrProd) ? "-stage" : ""; // go to staged for development
+  // did this so testing can be done without messing with anything in production database
+  const userRef = collection(db, "users" + extra);
+  const eSportsRef = collection(db, "user-e-sports-details" + extra);
+  const registerRef = collection(db, "user-registration-details" + extra);
 
   const router = useRouter();
 


### PR DESCRIPTION
### Description

I was just thinking that accounts used for testing in development might want to be separate from the production accounts. I think this would be good since it could allow the team to have broader access rights to data in firestore if needed and be able to register for things without it being mixed in with the real accounts. It would also make it impossible for real accounts to team up with fake accounts by accident.

Typically this will be a summary of your ticket.

### What are you changing?

- Design questions

### Did you increase testing or code coverage?

NO

### Did you add any dependencies to the project?

NO

### Did you update the relevant documentation?

NO, there is no relevant documentation.
