### PR TITLE
:hammer: throws error if event will cause user to be under 0 points

### DIFF
--- a/projects/mybyte/pages/qrRead.tsx
+++ b/projects/mybyte/pages/qrRead.tsx
@@ -122,6 +122,7 @@ const QrRead: React.FC = () => {
     let outcomeStatus: ScanVisualStatus = "error";
     let eventId = "";
     let eventTitle = "";
+    let eventPoints = 0;
     let scannedNameForLog = "";
 
     try {
@@ -142,6 +143,7 @@ const QrRead: React.FC = () => {
       eventId = selectEl.value;
       eventTitle =
         events.find((e) => e.id === eventId)?.title ?? `Event ${eventId}`;
+      eventPoints = events.find((e) => e.id === eventId)?.points ?? 0;
 
       const name = await getNameOfUser(uid);
       if (!name) throw "User not found!";
@@ -152,6 +154,8 @@ const QrRead: React.FC = () => {
       let points = await getPoints(uid);
 
       setUser({ name, shirtSize, points });
+
+      if (points + eventPoints < 0) throw "Not enough points";
 
       await addAttendance(eventId, uid);
 


### PR DESCRIPTION
### Description

QR scanner will prevent adding attendance for specific event if the event will bring them below 0 points.

(i.e., for points store where "events" have a negative point value)

### What are you changing?

New error thrown in `qrRead.tsx`

### Did you increase testing or code coverage?

No

### Did you add any dependencies to the project?

No

### Did you update the relevant documentation?

No