### PR TITLE
Point Store BandAid Fix

### DIFF
--- a/projects/mybyte/interfaces/event.ts
+++ b/projects/mybyte/interfaces/event.ts
@@ -46,10 +46,15 @@ export const addAttendance = async (eventId: string, userId: string) => {
 
   const attendanceRef = collection(eventsRef, eventId, "attendance");
 
-  const alreadyAttended = await getDocs(
-    query(attendanceRef, where("uid", "==", userId)),
-  );
-  if (alreadyAttended.docs.length > 0) throw new Error("Already attended");
+  // Allows point store "events" to be "attended" multiple times
+  if (
+    !(snapshot.data() as Event).title.toLowerCase().includes("[point store]")
+  ) {
+    const alreadyAttended = await getDocs(
+      query(attendanceRef, where("uid", "==", userId)),
+    );
+    if (alreadyAttended.docs.length > 0) throw new Error("Already attended");
+  }
 
   await setDoc(doc(attendanceRef, userId), {
     uid: userId,


### PR DESCRIPTION
Point Store events can be "attended" multiple times, allowing a Hacker to purchase the same item multiple times.

### Description

Events that contain "[Point Store]" (case insensitive) in the title will bypass the attendance check, allowing the
user to "attend" multiple times.

### What are you changing?

`If` statement added to determine whether the event is a Point Store event, skipping the interior logic if it is.

### Did you increase testing or code coverage?

No, someone test this in prod plz

### Did you add any dependencies to the project?

No

### Did you update the relevant documentation?

No